### PR TITLE
Fix for system test failures for SR400

### DIFF
--- a/system_tests/lewis_emulators/stanford_sr400_photon_counter/device.py
+++ b/system_tests/lewis_emulators/stanford_sr400_photon_counter/device.py
@@ -2,7 +2,6 @@ from collections import OrderedDict
 from .states import DefaultState
 from lewis.devices import StateMachineDevice
 
-import random
 class SimulatedStanfordSr400PhotonCounter(StateMachineDevice):
 
     def _initialize_data(self):
@@ -12,7 +11,7 @@ class SimulatedStanfordSr400PhotonCounter(StateMachineDevice):
         self.count_a = 0
         self.count_b = 0
         self.counting: bool = False
-        self.status_byte: int = int("00000010", 2) # Each bit in a byte stands for a status bit initially all zero
+        self.status_byte: int = int("00000010", 2)
 
     def _get_state_handlers(self):
         return {
@@ -25,13 +24,6 @@ class SimulatedStanfordSr400PhotonCounter(StateMachineDevice):
     def _get_transition_handlers(self):
         return OrderedDict([])
 
-    def set_random_status(self) -> None:
-        bit_string = ""
-        for _ in range(8):
-            bit_string += str(random.randint(0, 1))
-        
-        self.status_byte = int(bit_string, 2)
-
     def get_count_a(self) -> int:
         if self.counting:
             self.count_a = 20
@@ -43,10 +35,6 @@ class SimulatedStanfordSr400PhotonCounter(StateMachineDevice):
         return self.count_b
     
     def get_status(self) -> int:
-        #if self.counting:
-            # change status on
-            #self.set_random_status()
-        
         return self.status_byte
     
     def start_counting(self) -> None:

--- a/system_tests/lewis_emulators/stanford_sr400_photon_counter/device.py
+++ b/system_tests/lewis_emulators/stanford_sr400_photon_counter/device.py
@@ -34,18 +34,18 @@ class SimulatedStanfordSr400PhotonCounter(StateMachineDevice):
 
     def get_count_a(self) -> int:
         if self.counting:
-            self.count_a += random.randint(10, 15)
+            self.count_a = 20
         return self.count_a
 
     def get_count_b(self) -> int:
         if self.counting:
-            self.count_b += random.randint(10, 15)
+            self.count_b = 15
         return self.count_b
     
     def get_status(self) -> int:
-        if self.counting:
+        #if self.counting:
             # change status on
-            self.set_random_status()
+            #self.set_random_status()
         
         return self.status_byte
     

--- a/system_tests/tests/tests.py
+++ b/system_tests/tests/tests.py
@@ -72,7 +72,12 @@ class StanfordSr400PhotonCounterTests(unittest.TestCase):
 
     def test_status_changes(self):
         self._simulate_start_button_press()  # The fact that this works has been tested above
+        self._lewis.backdoor_set_on_device("status_byte", int("00000100", 2))
+        status = self.ca.get_pv_value("STATUS")
+        self.ca.assert_that_pv_is("STATUS", int("00000100", 2))
+
+        self._lewis.backdoor_set_on_device("status_byte", int("00000010", 2))
         status = self.ca.get_pv_value("STATUS")
 
-        self.ca.assert_that_pv_is_not("STATUS", 0)
+        self.ca.assert_that_pv_is("STATUS", int("00000010", 2))
 

--- a/system_tests/tests/tests.py
+++ b/system_tests/tests/tests.py
@@ -74,8 +74,5 @@ class StanfordSr400PhotonCounterTests(unittest.TestCase):
         self._simulate_start_button_press()  # The fact that this works has been tested above
         status = self.ca.get_pv_value("STATUS")
 
-        self.ca.assert_that_pv_is_not("STATUS", status)
-        status = self.ca.get_pv_value("STATUS")
-
-        self.ca.assert_that_pv_is_not("STATUS", status)
+        self.ca.assert_that_pv_is_not("STATUS", 0)
 


### PR DESCRIPTION
Removed the random generators from the device code.